### PR TITLE
Use colors array instead of colour1 and colour2

### DIFF
--- a/gradients.json
+++ b/gradients.json
@@ -1,522 +1,418 @@
 [
   {
-    "name":"Emerald Water",
-    "colour1":"#348F50",
-    "colour2":"#56B4D3"
+    "name": "Emerald Water",
+    "colors": ["#348F50", "#56B4D3"]
   },
   {
-    "name":"Lemon Twist",
-    "colour1":"#3CA55C",
-    "colour2":"#B5AC49"
+    "name": "Lemon Twist",
+    "colors": ["#3CA55C", "#B5AC49"]
   },
   {
-    "name":"Horizon",
-    "colour1":"#003973",
-    "colour2":"#E5E5BE"
+    "name": "Horizon",
+    "colors": ["#003973", "#E5E5BE"]
   },
   {
-    "name":"Rose Water",
-    "colour1":"#E55D87",
-    "colour2":"#5FC3E4"
+    "name": "Rose Water",
+    "colors": ["#E55D87", "#5FC3E4"]
   },
   {
-    "name":"Frozen",
-    "colour1":"#403B4A",
-    "colour2":"#E7E9BB"
+    "name": "Frozen",
+    "colors": ["#403B4A", "#E7E9BB"]
   },
   {
-    "name":"Mango Pulp",
-    "colour1":"#F09819",
-    "colour2":"#EDDE5D"
+    "name": "Mango Pulp",
+    "colors": ["#F09819", "#EDDE5D"]
   },
   {
-    "name":"Bloody Mary",
-    "colour1":"#FF512F",
-    "colour2":"#DD2476"
+    "name": "Bloody Mary",
+    "colors": ["#FF512F", "#DD2476"]
   },
   {
-    "name":"Aubergine",
-    "colour1":"#AA076B",
-    "colour2":"#61045F"
+    "name": "Aubergine",
+    "colors": ["#AA076B", "#61045F"]
   },
   {
-    "name":"Aqua Marine",
-    "colour1":"#1A2980",
-    "colour2":"#26D0CE"
+    "name": "Aqua Marine",
+    "colors": ["#1A2980", "#26D0CE"]
   },
   {
-    "name":"Sunrise",
-    "colour1":"#FF512F",
-    "colour2":"#F09819"
+    "name": "Sunrise",
+    "colors": ["#FF512F", "#F09819"]
   },
   {
-    "name":"Purple Paradise",
-    "colour1":"#1D2B64",
-    "colour2":"#F8CDDA"
+    "name": "Purple Paradise",
+    "colors": ["#1D2B64", "#F8CDDA"]
   },
   {
-    "name":"Sea Weed",
-    "colour1":"#4CB8C4",
-    "colour2":"#3CD3AD"
+    "name": "Sea Weed",
+    "colors": ["#4CB8C4", "#3CD3AD"]
   },
   {
-    "name":"Pinky",
-    "colour1":"#DD5E89",
-    "colour2":"#F7BB97"
+    "name": "Pinky",
+    "colors": ["#DD5E89", "#F7BB97"]
   },
   {
-    "name":"Cherry",
-    "colour1":"#EB3349",
-    "colour2":"#F45C43"
+    "name": "Cherry",
+    "colors": ["#EB3349", "#F45C43"]
   },
   {
-    "name":"Mojito",
-    "colour1":"#1D976C",
-    "colour2":"#93F9B9"
+    "name": "Mojito",
+    "colors": ["#1D976C", "#93F9B9"]
   },
   {
-    "name":"Juicy Orange",
-    "colour1":"#FF8008",
-    "colour2":"#FFC837"
+    "name": "Juicy Orange",
+    "colors": ["#FF8008", "#FFC837"]
   },
   {
-    "name":"Mirage",
-    "colour1":"#16222A",
-    "colour2":"#3A6073"
+    "name": "Mirage",
+    "colors": ["#16222A", "#3A6073"]
   },
   {
-    "name":"Steel Gray",
-    "colour1":"#1F1C2C",
-    "colour2":"#928DAB"
+    "name": "Steel Gray",
+    "colors": ["#1F1C2C", "#928DAB"]
   },
   {
-    "name":"Kashmir",
-    "colour1":"#614385",
-    "colour2":"#516395"
+    "name": "Kashmir",
+    "colors": ["#614385", "#516395"]
   },
   {
-    "name":"Electric Violet",
-    "colour1":"#4776E6",
-    "colour2":"#8E54E9"
+    "name": "Electric Violet",
+    "colors": ["#4776E6", "#8E54E9"]
   },
   {
-    "name":"Venice Blue",
-    "colour1":"#085078",
-    "colour2":"#85D8CE"
+    "name": "Venice Blue",
+    "colors": ["#085078", "#85D8CE"]
   },
   {
-    "name":"Bora Bora",
-    "colour1":"#2BC0E4",
-    "colour2":"#EAECC6"
+    "name": "Bora Bora",
+    "colors": ["#2BC0E4", "#EAECC6"]
   },
   {
-    "name":"Moss",
-    "colour1":"#134E5E",
-    "colour2":"#71B280"
+    "name": "Moss",
+    "colors": ["#134E5E", "#71B280"]
   },
   {
-    "name":"Shroom Haze",
-    "colour1":"#5C258D",
-    "colour2":"#4389A2"
+    "name": "Shroom Haze",
+    "colors": ["#5C258D", "#4389A2"]
   },
   {
-    "name":"Mystic",
-    "colour1":"#757F9A",
-    "colour2":"#D7DDE8"
+    "name": "Mystic",
+    "colors": ["#757F9A", "#D7DDE8"]
   },
   {
-    "name":"Midnight City",
-    "colour1":"#232526",
-    "colour2":"#414345"
+    "name": "Midnight City",
+    "colors": ["#232526", "#414345"]
   },
   {
-    "name":"Sea Blizz",
-    "colour1":"#1CD8D2",
-    "colour2":"#93EDC7"
+    "name": "Sea Blizz",
+    "colors": ["#1CD8D2", "#93EDC7"]
   },
   {
-    "name":"Opa",
-    "colour1":"#3D7EAA",
-    "colour2":"#FFE47A"
+    "name": "Opa",
+    "colors": ["#3D7EAA", "#FFE47A"]
   },
   {
-    "name":"Titanium",
-    "colour1":"#283048",
-    "colour2":"#859398"
+    "name": "Titanium",
+    "colors": ["#283048", "#859398"]
   },
   {
-    "name":"Mantle",
-    "colour1":"#24C6DC",
-    "colour2":"#514A9D"
+    "name": "Mantle",
+    "colors": ["#24C6DC", "#514A9D"]
   },
   {
-    "name":"Dracula",
-    "colour1":"#DC2424",
-    "colour2":"#4A569D"
+    "name": "Dracula",
+    "colors": ["#DC2424", "#4A569D"]
   },
   {
-    "name":"Peach",
-    "colour1":"#ED4264",
-    "colour2":"#FFEDBC"
+    "name": "Peach",
+    "colors": ["#ED4264", "#FFEDBC"]
   },
   {
-    "name":"Moonrise",
-    "colour1":"#DAE2F8",
-    "colour2":"#D6A4A4"
+    "name": "Moonrise",
+    "colors": ["#DAE2F8", "#D6A4A4"]
   },
   {
-    "name":"Clouds",
-    "colour1":"#ECE9E6",
-    "colour2":"#FFFFFF"
+    "name": "Clouds",
+    "colors": ["#ECE9E6", "#FFFFFF"]
   },
   {
-    "name":"Stellar",
-    "colour1":"#7474BF",
-    "colour2":"#348AC7"
+    "name": "Stellar",
+    "colors": ["#7474BF", "#348AC7"]
   },
   {
-    "name":"Bourbon",
-    "colour1":"#EC6F66",
-    "colour2":"#F3A183"
+    "name": "Bourbon",
+    "colors": ["#EC6F66", "#F3A183"]
   },
   {
-    "name":"Calm Darya",
-    "colour1":"#5f2c82",
-    "colour2":"#49a09d"
+    "name": "Calm Darya",
+    "colors": ["#5f2c82", "#49a09d"]
   },
   {
-    "name":"Influenza",
-    "colour1":"#C04848",
-    "colour2":"#480048"
+    "name": "Influenza",
+    "colors": ["#C04848", "#480048"]
   },
   {
-    "name":"Shrimpy",
-    "colour1":"#e43a15",
-    "colour2":"#e65245"
+    "name": "Shrimpy",
+    "colors": ["#e43a15", "#e65245"]
   },
   {
-    "name":"Army",
-    "colour1":"#414d0b",
-    "colour2":"#727a17"
+    "name": "Army",
+    "colors": ["#414d0b", "#727a17"]
   },
   {
-    "name":"Miaka",
-    "colour1":"#FC354C",
-    "colour2":"#0ABFBC"
+    "name": "Miaka",
+    "colors": ["#FC354C", "#0ABFBC"]
   },
   {
-    "name":"Pinot Noir",
-    "colour1":"#4b6cb7",
-    "colour2":"#182848"
+    "name": "Pinot Noir",
+    "colors": ["#4b6cb7", "#182848"]
   },
   {
-    "name":"Day Tripper",
-    "colour1":"#f857a6",
-    "colour2":"#ff5858"
+    "name": "Day Tripper",
+    "colors": ["#f857a6", "#ff5858"]
   },
   {
-    "name":"Namn",
-    "colour1":"#a73737",
-    "colour2":"#7a2828"
+    "name": "Namn",
+    "colors": ["#a73737", "#7a2828"]
   },
   {
-    "name":"Blurry Beach",
-    "colour1":"#d53369",
-    "colour2":"#cbad6d"
+    "name": "Blurry Beach",
+    "colors": ["#d53369", "#cbad6d"]
   },
   {
-    "name":"Vasily",
-    "colour1":"#e9d362",
-    "colour2":"#333333"
+    "name": "Vasily",
+    "colors": ["#e9d362", "#333333"]
   },
   {
-    "name":"A Lost Memory",
-    "colour1":"#DE6262",
-    "colour2":"#FFB88C"
+    "name": "A Lost Memory",
+    "colors": ["#DE6262", "#FFB88C"]
   },
   {
-    "name":"Petrichor",
-    "colour1":"#666600",
-    "colour2":"#999966"
+    "name": "Petrichor",
+    "colors": ["#666600", "#999966"]
   },
   {
-    "name":"Jonquil",
-    "colour1":"#FFEEEE",
-    "colour2":"#DDEFBB"
+    "name": "Jonquil",
+    "colors": ["#FFEEEE", "#DDEFBB"]
   },
   {
-    "name":"Sirius Tamed",
-    "colour1":"#EFEFBB",
-    "colour2":"#D4D3DD"
+    "name": "Sirius Tamed",
+    "colors": ["#EFEFBB", "#D4D3DD"]
   },
   {
-    "name":"Kyoto",
-    "colour1":"#c21500",
-    "colour2":"#ffc500"
+    "name": "Kyoto",
+    "colors": ["#c21500", "#ffc500"]
   },
   {
-    "name":"Misty Meadow",
-    "colour1":"#215f00",
-    "colour2":"#e4e4d9"
+    "name": "Misty Meadow",
+    "colors": ["#215f00", "#e4e4d9"]
   },
   {
-    "name":"Aqualicious",
-    "colour1":"#50C9C3",
-    "colour2":"#96DEDA"
+    "name": "Aqualicious",
+    "colors": ["#50C9C3", "#96DEDA"]
   },
   {
-    "name":"Moor",
-    "colour1":"#616161",
-    "colour2":"#9bc5c3"
+    "name": "Moor",
+    "colors": ["#616161", "#9bc5c3"]
   },
   {
-    "name":"Almost",
-    "colour1":"#ddd6f3",
-    "colour2":"#faaca8"
+    "name": "Almost",
+    "colors": ["#ddd6f3", "#faaca8"]
   },
   {
-    "name":"Forever Lost",
-    "colour1":"#5D4157",
-    "colour2":"#A8CABA"
+    "name": "Forever Lost",
+    "colors": ["#5D4157", "#A8CABA"]
   },
   {
-    "name":"Winter",
-    "colour1":"#E6DADA",
-    "colour2":"#274046"
+    "name": "Winter",
+    "colors": ["#E6DADA", "#274046"]
   },
   {
-    "name":"Autumn",
-    "colour1":"#DAD299",
-    "colour2":"#B0DAB9"
+    "name": "Autumn",
+    "colors": ["#DAD299", "#B0DAB9"]
   },
   {
-    "name":"Candy",
-    "colour1":"#D3959B",
-    "colour2":"#BFE6BA"
+    "name": "Candy",
+    "colors": ["#D3959B", "#BFE6BA"]
   },
   {
-    "name":"Reef",
-    "colour1":"#00d2ff",
-    "colour2":"#3a7bd5"
+    "name": "Reef",
+    "colors": ["#00d2ff", "#3a7bd5"]
   },
   {
-    "name":"The Strain",
-    "colour1":"#870000",
-    "colour2":"#190A05"
+    "name": "The Strain",
+    "colors": ["#870000", "#190A05"]
   },
   {
-    "name":"Dirty Fog",
-    "colour1":"#B993D6",
-    "colour2":"#8CA6DB"
+    "name": "Dirty Fog",
+    "colors": ["#B993D6", "#8CA6DB"]
   },
   {
-    "name":"Earthly",
-    "colour1":"#649173",
-    "colour2":"#DBD5A4"
+    "name": "Earthly",
+    "colors": ["#649173", "#DBD5A4"]
   },
   {
-    "name":"Virgin",
-    "colour1":"#C9FFBF",
-    "colour2":"#FFAFBD"
+    "name": "Virgin",
+    "colors": ["#C9FFBF", "#FFAFBD"]
   },
   {
-    "name":"Ash",
-    "colour1":"#606c88",
-    "colour2":"#3f4c6b"
+    "name": "Ash",
+    "colors": ["#606c88", "#3f4c6b"]
   },
   {
-    "name":"Shadow Night",
-    "colour1":"#000000",
-    "colour2":"#53346D"
+    "name": "Shadow Night",
+    "colors": ["#000000", "#53346D"]
   },
   {
-    "name":"Cherryblossoms",
-    "colour1":"#FBD3E9",
-    "colour2":"#BB377D"
+    "name": "Cherryblossoms",
+    "colors": ["#FBD3E9", "#BB377D"]
   },
   {
-    "name":"Parklife",
-    "colour1":"#ADD100",
-    "colour2":"#7B920A"
+    "name": "Parklife",
+    "colors": ["#ADD100", "#7B920A"]
   },
   {
-    "name":"Dance To Forget",
-    "colour1":"#FF4E50",
-    "colour2":"#F9D423"
+    "name": "Dance To Forget",
+    "colors": ["#FF4E50", "#F9D423"]
   },
   {
-    "name":"Starfall",
-    "colour1":"#F0C27B",
-    "colour2":"#4B1248"
+    "name": "Starfall",
+    "colors": ["#F0C27B", "#4B1248"]
   },
   {
-    "name":"Red Mist",
-    "colour1":"#000000",
-    "colour2":"#e74c3c"
+    "name": "Red Mist",
+    "colors": ["#000000", "#e74c3c"]
   },
   {
-    "name":"Teal Love",
-    "colour1":"#AAFFA9",
-    "colour2":"#11FFBD"
+    "name": "Teal Love",
+    "colors": ["#AAFFA9", "#11FFBD"]
   },
   {
-    "name":"Neon Life",
-    "colour1":"#B3FFAB",
-    "colour2":"#12FFF7"
+    "name": "Neon Life",
+    "colors": ["#B3FFAB", "#12FFF7"]
   },
   {
-    "name":"Man of Steel",
-    "colour1":"#780206",
-    "colour2":"#061161"
+    "name": "Man of Steel",
+    "colors": ["#780206", "#061161"]
   },
   {
-    "name":"Amethyst",
-    "colour1":"#9D50BB",
-    "colour2":"#6E48AA"
+    "name": "Amethyst",
+    "colors": ["#9D50BB", "#6E48AA"]
   },
   {
-    "name":"Cheer Up Emo Kid",
-    "colour1":"#556270",
-    "colour2":"#FF6B6B"
+    "name": "Cheer Up Emo Kid",
+    "colors": ["#556270", "#FF6B6B"]
   },
   {
-    "name":"Shore",
-    "colour1":"#70e1f5",
-    "colour2":"#ffd194"
+    "name": "Shore",
+    "colors": ["#70e1f5", "#ffd194"]
   },
   {
-    "name":"Facebook Messenger",
-    "colour1":"#00c6ff",
-    "colour2":"#0072ff"
+    "name": "Facebook Messenger",
+    "colors": ["#00c6ff", "#0072ff"]
   },
   {
-    "name":"SoundCloud",
-    "colour1":"#fe8c00",
-    "colour2":"#f83600"
+    "name": "SoundCloud",
+    "colors": ["#fe8c00", "#f83600"]
   },
   {
-    "name":"Behongo",
-    "colour1":"#52c234",
-    "colour2":"#061700"
+    "name": "Behongo",
+    "colors": ["#52c234", "#061700"]
   },
   {
-    "name":"ServQuick",
-    "colour1":"#485563",
-    "colour2":"#29323c"
+    "name": "ServQuick",
+    "colors": ["#485563", "#29323c"]
   },
   {
-    "name":"Friday",
-    "colour1":"#83a4d4",
-    "colour2":"#b6fbff"
+    "name": "Friday",
+    "colors": ["#83a4d4", "#b6fbff"]
   },
   {
-    "name":"Martini",
-    "colour1":"#FDFC47",
-    "colour2":"#24FE41"
+    "name": "Martini",
+    "colors": ["#FDFC47", "#24FE41"]
   },
   {
-    "name":"Metallic Toad",
-    "colour1":"#abbaab",
-    "colour2":"#ffffff"
+    "name": "Metallic Toad",
+    "colors": ["#abbaab", "#ffffff"]
   },
   {
-    "name":"Between The Clouds",
-    "colour1":"#73C8A9",
-    "colour2":"#373B44"
+    "name": "Between The Clouds",
+    "colors": ["#73C8A9", "#373B44"]
   },
   {
-    "name":"Crazy Orange I",
-    "colour1":"#D38312",
-    "colour2":"#A83279"
+    "name": "Crazy Orange I",
+    "colors": ["#D38312", "#A83279"]
   },
   {
-    "name":"Hersheys",
-    "colour1":"#1e130c",
-    "colour2":"#9a8478"
+    "name": "Hersheys",
+    "colors": ["#1e130c", "#9a8478"]
   },
   {
-    "name":"Talking To Mice Elf",
-    "colour1":"#948E99",
-    "colour2":"#2E1437"
+    "name": "Talking To Mice Elf",
+    "colors": ["#948E99", "#2E1437"]
   },
   {
-    "name":"Purple Bliss",
-    "colour1":"#360033",
-    "colour2":"#0b8793"
+    "name": "Purple Bliss",
+    "colors": ["#360033", "#0b8793"]
   },
   {
-    "name":"Predawn",
-    "colour1":"#FFA17F",
-    "colour2":"#00223E"
+    "name": "Predawn",
+    "colors": ["#FFA17F", "#00223E"]
   },
   {
-    "name":"Endless River",
-    "colour1":"#43cea2",
-    "colour2":"#185a9d"
+    "name": "Endless River",
+    "colors": ["#43cea2", "#185a9d"]
   },
   {
-    "name":"Pastel Orange at the Sun",
-    "colour1":"#ffb347",
-    "colour2":"#ffcc33"
+    "name": "Pastel Orange at the Sun",
+    "colors": ["#ffb347", "#ffcc33"]
   },
   {
     "name": "Twitch",
-    "colour1": "#6441A5",
-    "colour2": "#2a0845"
+    "colors": ["#6441A5", "#2a0845"]
   },
   {
     "name": "Instagram",
-    "colour1": "#517fa4",
-    "colour2": "#243949"
+    "colors": ["#517fa4", "#243949"]
   },
   {
     "name": "Flickr",
-    "colour1": "#ff0084",
-    "colour2": "#33001b"
+    "colors": ["#ff0084", "#33001b"]
   },
   {
     "name": "Vine",
-    "colour1": "#00bf8f",
-    "colour2": "#001510"
+    "colors": ["#00bf8f", "#001510"]
   },
   {
     "name": "Turquoise flow",
-    "colour1": "#136a8a",
-    "colour2": "#267871"
+    "colors": ["#136a8a", "#267871"]
   },
   {
     "name": "Portrait",
-    "colour1": "#8e9eab",
-    "colour2": "#eef2f3"
+    "colors": ["#8e9eab", "#eef2f3"]
   },
   {
     "name": "Virgin America",
-    "colour1": "#7b4397",
-    "colour2": "#dc2430"
+    "colors": ["#7b4397", "#dc2430"]
   },
   {
-    "name":"Koko Caramel",
-    "colour1":"#D1913C",
-    "colour2":"#FFD194"
+    "name": "Koko Caramel",
+    "colors": ["#D1913C", "#FFD194"]
   },
   {
-    "name":"Fresh Turboscent",
-    "colour1":"#F1F2B5",
-    "colour2":"#135058"
+    "name": "Fresh Turboscent",
+    "colors": ["#F1F2B5", "#135058"]
   },
   {
-    "name":"Green to dark",
-    "colour1":"#6A9113",
-    "colour2":"#141517"
+    "name": "Green to dark",
+    "colors": ["#6A9113", "#141517"]
   },
   {
-    "name":"Ukraine",
-    "colour1":"#004FF9",
-    "colour2":"#FFF94C"
+    "name": "Ukraine",
+    "colors": ["#004FF9", "#FFF94C"]
   },
   {
-    "name":"Curiosity blue",
-    "colour1":"#525252",
-    "colour2":"#3d72b4"
+    "name": "Curiosity blue",
+    "colors": ["#525252", "#3d72b4"]
   }
 ]


### PR DESCRIPTION
Uses `colors` array instead of `colour1` and `colour2`.

For those interested, I did a regular expression search & replace using:
`"colour1":\s?(.+,)\s+"colour2":\s?(.+)` **->** `"colors": [$1 $2]`

I also put a space between the name key and its value: `"name":"` **->** `"name": "`

Implements #16.