### PR TITLE
Quot marks around hex color in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To add your gradient, fork this repository, add your two gradient colours in the
         },
         {
       		"name": "Emerald Water",
-      		"colors": ["#348F50", #56B4D3]
+      		"colors": ["#348F50", "#56B4D3"]
         }
     ]
 


### PR DESCRIPTION
The proper format suggests having quotation marks around both gradient colors, the example only had them around the first color.