### PR TITLE
Hide "on Facebook" & "on twitter"  for smaller screen (More Gradients added).

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -107,13 +107,13 @@ I'm @_ighosh on twitter.
       <!-- https://developers.facebook.com/docs/plugins/share-button/ -->
       <a target="_blank" href="http://www.facebook.com/sharer.php?u=http://uigradients.com" class="share-facebook" id="share-facebook">
         <span class="icon icon-facebook"></span>
-        <span class="share-title">Share on Facebook</span>
+        <span class="share-title">Share <span class="hide-on-med">on Facebook</span></span>
       </a>
 
       <!-- https://dev.twitter.com/docs/intents -->
       <a target="_blank" href="http://twitter.com/share?url=http://uigradients.com&amp;text=Beautiful%20colour%20gradients%20for%20designers%20and%20developers&amp;via=_ighosh" class="share-twitter" id="share-twitter">
         <span class="icon icon-twitter"></span>
-        <span class="share-title">Share on Twitter</span>
+        <span class="share-title">Share <span class="hide-on-med">on Twitter</span></span>
       </a>
 
     </div>

--- a/build/index.html
+++ b/build/index.html
@@ -43,7 +43,7 @@ I'm @_ighosh on twitter.
   <link rel="icon" type="image/png" href="assets/images/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
  	<!-- Hide "on Facebook" & "on twitter"  for smaller screen-->
- 	<style type="text/css">@media only screen and (max-width: 720px) {.hide-on-med{ display: none;}}</style>
+ 	<style type="text/css">@media only screen and (max-width: 767px) {.hide-on-med{display: none !important;}}</style>
 
 </head>
 

--- a/build/index.html
+++ b/build/index.html
@@ -42,6 +42,8 @@ I'm @_ighosh on twitter.
 
   <link rel="icon" type="image/png" href="assets/images/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="assets/images/favicon-16x16.png" sizes="16x16" />
+ 	<!-- Hide "on Facebook" & "on twitter"  for smaller screen-->
+ 	<style type="text/css">@media only screen and (max-width: 720px) {.hide-on-med{ display: none;}}</style>
 
 </head>
 

--- a/gradients.json
+++ b/gradients.json
@@ -647,5 +647,10 @@
     {
         "name": "Blasting Blue",
         "colors": [ "#0d47a1","#01579b" ]
+    },
+    {
+        "name": "Panning Purple",
+        "colors": [ "#311b92","#8e24aa" ]
     }
+    
 ]

--- a/gradients.json
+++ b/gradients.json
@@ -651,6 +651,9 @@
     {
         "name": "Panning Purple",
         "colors": [ "#311b92","#8e24aa" ]
+    },{
+        "name": "Leaf",
+        "colors": ["#33670E","#79550A"]
     }
     
 ]

--- a/gradients.json
+++ b/gradients.json
@@ -654,6 +654,8 @@
     },{
         "name": "Leaf",
         "colors": ["#33670E","#79550A"]
+    },{
+        "name": "Cynic Sky",
+        "colors" : ["#b2ebf2","#c5e1a5"]
     }
-    
 ]

--- a/gradients.json
+++ b/gradients.json
@@ -643,5 +643,9 @@
     {
         "name": "Dusk",
         "colors": ["#2C3E50", "#FD746C"]
+    },
+    {
+        "name": "Blasting Blue",
+        "colors": [ "#0d47a1","#01579b" ]
     }
 ]


### PR DESCRIPTION
When It comes to smaller screen, Share buttons were breaking row.
![prob](https://cloud.githubusercontent.com/assets/8057628/17079320/02dfb26c-512a-11e6-90c0-7dea1b9062ac.png)
<hr>
So i've done a commit with solution of that problem that hides texts  "on Facebook" & "on twitter" on smaller screen.
![solved1](https://cloud.githubusercontent.com/assets/8057628/17079321/0698d78a-512a-11e6-86d7-55431cada3b3.png)
