### PR TITLE
Correct colors for Telegram gradient

### DIFF
--- a/gradients.json
+++ b/gradients.json
@@ -940,7 +940,7 @@
     },
     {
         "name": "Telegram",
-        "colors": ["#1c92d2", "#0f9b0f"]
+        "colors": ["#1c92d2", "#f2fcfe"]
     },
     {
         "name": "Crimson Tide",


### PR DESCRIPTION
According to my own comment for #226, the correct color for Telegram gradient is blue-white, not blue-green.
Sorry, it looks like I just sent the wrong color in the last time