### PR TITLE
Delete width property from buttons to fix button text crashing

### DIFF
--- a/src/stylesheets/components/_buttons.scss
+++ b/src/stylesheets/components/_buttons.scss
@@ -13,7 +13,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 140px;
   transition: background-color 0.2s ease-in-out;
 
   span { @include font-smoothing(); }


### PR DESCRIPTION
With the original fixed with buttons, Tweeter is fine but Facebook button is crashing texts.