### PR TITLE
Fix CSS color order bug

### DIFF
--- a/src/components/modals/CodeModal.vue
+++ b/src/components/modals/CodeModal.vue
@@ -13,8 +13,8 @@
 
 <pre class="codeblock" v-else><code>
   <span class="codeblock__property">background</span>: <span class="codeblock__spec">{{ this.gradient.colors[0] | lowercase }}</span>; <span class="codeblock__comment">/* fallback for old browsers */</span>
-  <span class="codeblock__property">background</span>: -webkit-linear-gradient({{ this.direction }}, <span class="codeblock__spec">{{ [...this.gradient.colors].reverse().join(', ') | lowercase }}</span>); <span class="codeblock__comment">/* Chrome 10-25, Safari 5.1-6 */</span>
-  <span class="codeblock__property">background</span>: linear-gradient({{ this.direction }}, <span class="codeblock__spec">{{ [...this.gradient.colors].reverse().join(', ') | lowercase }}</span>); <span class="codeblock__comment">/* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */</span>
+  <span class="codeblock__property">background</span>: -webkit-linear-gradient({{ this.direction }}, <span class="codeblock__spec">{{ [...this.gradient.colors] | lowercase }}</span>); <span class="codeblock__comment">/* Chrome 10-25, Safari 5.1-6 */</span>
+  <span class="codeblock__property">background</span>: linear-gradient({{ this.direction }}, <span class="codeblock__spec">{{ [...this.gradient.colors] | lowercase }}</span>); <span class="codeblock__comment">/* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */</span>
 </code></pre>
 
 </div>
@@ -54,8 +54,8 @@ export default {
   computed: {
     copyData() {
       return `background: ${this.gradient.colors[0]};  /* fallback for old browsers */
-background: -webkit-linear-gradient(${this.direction}, ${[...this.gradient.colors].reverse().join(', ')});  /* Chrome 10-25, Safari 5.1-6 */
-background: linear-gradient(${this.direction}, ${[...this.gradient.colors].reverse().join(', ')}); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+background: -webkit-linear-gradient(${this.direction}, ${[...this.gradient.colors]});  /* Chrome 10-25, Safari 5.1-6 */
+background: linear-gradient(${this.direction}, ${[...this.gradient.colors]}); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
 `;
     },
   },


### PR DESCRIPTION
This PR addresses #453 

Before the first fix attempt made in PR #497, the array was only reversed in `CodeModal.copyData()`. The fix from 497 reversed the array in `codeblock` *and* `copyData()` with this technique: `[...this.gradient.colors].reverse().join(',')`. This however created a copies of the original array twice, and reversed each copy.

To fix this, `reverse()` was removed from both `codeblock`, and `copyData()`. This prevents the array from being modified again before the user copy's the CSS data. Below is a demo featuring the gradient https://uigradients.com/#Margo referenced in the referenced issue:

<img src="https://user-images.githubusercontent.com/9587680/41634923-91e70758-7478-11e8-835f-c718f7aa3e47.jpg"/>

**Copied CSS w/ Fix:**
```css
background: #FFEFBA;  /* fallback for old browsers */
background: -webkit-linear-gradient(to top, #FFEFBA,#FFFFFF);  /* Chrome 10-25, Safari 5.1-6 */
background: linear-gradient(to top, #FFEFBA,#FFFFFF); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
```
